### PR TITLE
Omit localedef on macOS because it never succeeds

### DIFF
--- a/Formula/tmux-head.rb
+++ b/Formula/tmux-head.rb
@@ -81,9 +81,11 @@ class TmuxHead < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end

--- a/Formula/tmux@3.3.rb
+++ b/Formula/tmux@3.3.rb
@@ -66,9 +66,11 @@ class TmuxAT33 < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end

--- a/Formula/tmux@3.3a.rb
+++ b/Formula/tmux@3.3a.rb
@@ -67,9 +67,11 @@ class TmuxAT33a < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end

--- a/Formula/tmux@3.4.rb
+++ b/Formula/tmux@3.4.rb
@@ -68,9 +68,11 @@ class TmuxAT34 < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end

--- a/Formula/tmux@3.5.rb
+++ b/Formula/tmux@3.5.rb
@@ -68,9 +68,11 @@ class TmuxAT35 < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end

--- a/Formula/tmux@3.5a.rb
+++ b/Formula/tmux@3.5a.rb
@@ -68,9 +68,11 @@ class TmuxAT35a < Formula
   end
 
   def post_install
+    return unless OS.linux?
+
     ohai "Installing locale data for {ja_JP, zh_*, ko_*, ...}.UTF-8"
 
-    localedef = OS.linux? ? (Formula["glibc"].opt_bin/"localedef") : "localedef"
+    localedef = Formula["glibc"].opt_bin/"localedef"
     %w[ja_JP zh_CN zh_HK zh_SG zh_TW ko_KR en_US].each do |lang|
       system localedef, "-i", lang, "-f", "UTF-8", "#{lang}.UTF-8"
     end


### PR DESCRIPTION
It only causes this error: `fopen: No such file or directory`